### PR TITLE
Task Improvements

### DIFF
--- a/lib/task.rb
+++ b/lib/task.rb
@@ -1,6 +1,7 @@
 require "task/version"
-require_relative 'task/task'
 require_relative 'task/data_interface'
+require_relative 'task/task'
+require_relative 'task/tasks'
 require_relative 'task/generators'
 
 module Task; end

--- a/lib/task/task.rb
+++ b/lib/task/task.rb
@@ -66,6 +66,17 @@ module Task
         new(task_list: task_list, id: id, data: options)
       end
 
+      # Instantiate an instance of this Task subclass and save it to the datastore.
+      # @param options [Hash] Options to instantiate this Task. :task_list and :id are required;
+      #   other arguments will be passed as data to the task.
+      # @option options [String] :task_list
+      # @option options [String] :id
+      def create(options)
+        task = build(options)
+        task.save
+        task
+      end
+
       # Defines an attr reader instance method for a field in the data hash.
       #
       # @example
@@ -121,6 +132,12 @@ module Task
       DataInterface::Interface.new
     end
 
+    # Executes this task
+    # @param options [Hash] Options specific to the execution of this task
+    def execute(options = {})
+      raise NotImplementedError.new('execute method not implemented')
+    end
+
     # Serialized this Task as a hash
     # @return [Hash]
     def as_hash
@@ -133,6 +150,7 @@ module Task
       Task.interface.store(self)
       nil
     end
+
 
     # Marks this task as complete, removing it from the datastore
     # @return [NilClass]

--- a/lib/task/tasks.rb
+++ b/lib/task/tasks.rb
@@ -1,0 +1,1 @@
+require_relative 'tasks/composite_task.rb'

--- a/lib/task/tasks/composite_task.rb
+++ b/lib/task/tasks/composite_task.rb
@@ -1,0 +1,16 @@
+require_relative '../task'
+
+module Task::Tasks
+  class CompositeTask
+    include Task::Task
+
+    data_attr_reader :child_task_list
+
+    def execute(opts = {})
+      Task::Task.all(child_task_list).each do |task|
+        task.execute(opts)
+        task.complete
+      end
+    end
+  end
+end

--- a/lib/task/version.rb
+++ b/lib/task/version.rb
@@ -1,3 +1,3 @@
 module Task
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/test/task/task_test.rb
+++ b/test/task/task_test.rb
@@ -26,6 +26,44 @@ module Task
         task = ExampleTask.build(task_list: 'a', id: 'id', test_field: 1)
         assert_equal 1, task.test_field
       end
+
+      context 'serialization and deserialization' do
+        setup do
+          @task = ExampleTask.build(task_list: 'a', id: 'id', test_field: 1)
+          @recreated = Task.from_hash(@task.as_hash)
+        end
+
+        should 'recreate a task from its serialized hash form' do
+          assert_equal @task.attributes, @recreated.attributes
+        end
+
+        should 'reserialize the class of the task' do
+          assert_equal @task.class, @recreated.class
+        end
+
+        should 'raise an error if the serialized task class does not exist' do
+          task_hash = @task.as_hash.merge(type: 'NotAClass')
+          assert_raises(NameError) { Task.from_hash(task_hash) }
+        end
+      end
+
+      context '#create' do
+        setup do
+          initialize_task_table
+        end
+
+        teardown do
+          clear_task_table
+        end
+
+        should 'save the task to the datastore' do
+          task = ExampleTask.create(task_list: 'a')
+          all_tasks = Task.all(task.task_list).to_a
+
+          assert_equal 1, all_tasks.count
+          assert_equal task.attributes, all_tasks.first.attributes
+        end
+      end
     end
   end
 end

--- a/test/task/tasks/composite_task_test.rb
+++ b/test/task/tasks/composite_task_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+module Task::Tasks
+  class CompositeTaskTest < Minitest::Should::TestCase
+
+    class ExampleTask
+      include Task::Task
+
+      class << self
+        attr_accessor :executed_count
+      end
+
+      def execute(opts = {})
+        self.class.executed_count += 1
+      end
+
+      data_attr_reader :test_field
+    end
+
+    context 'a composite task' do
+
+      setup do
+        initialize_task_table
+        ExampleTask.executed_count = 0
+      end
+
+      teardown do
+        clear_task_table
+      end
+
+      should 'execute child tasks from the specified list when executed' do
+        ExampleTask.create(task_list: 'a', id: '1')
+        ExampleTask.create(task_list: 'a', id: '2')
+
+        CompositeTask.build(child_task_list: 'a', task_list: 'x').execute
+
+        assert_equal 2, ExampleTask.executed_count
+      end
+
+      should 'not execute child tasks from other task lists' do
+        ExampleTask.create(task_list: 'a', id: '1')
+        ExampleTask.create(task_list: 'a', id: '2')
+        ExampleTask.create(task_list: 'b', id: '3')
+
+        CompositeTask.build(child_task_list: 'a', task_list: 'x').execute
+
+        assert_equal 2, ExampleTask.executed_count
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds Task#execute method, clarifying the signature and method through
  which a task can execute itself.
- Add Task.create method, which will build a task and save it to the
  datastore.
- Adds the Task::Tasks::CompositeTask task, which executes and completes
  all child tasks from a given (other) task list.
