### PR TITLE
Loosen version restrictions on pyper version

### DIFF
--- a/task_rb.gemspec
+++ b/task_rb.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-reporters"
 
-  spec.add_dependency 'pyper_rb', '~> 1.0.0'
+  spec.add_dependency 'pyper_rb', '~> 1.0'
   spec.add_dependency 'cassava_rb'
   spec.add_dependency 'virtus'
   spec.add_dependency 'values'


### PR DESCRIPTION
No need to depend on 1.0.x, instead depend on 1.x.x
