### PR TITLE
Pool Cassandra connections during tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,9 +13,9 @@ class Minitest::Should::TestCase
   end
 end
 
+POOL = {}
 def session_for_keyspace(keyspace = 'test_tasks')
-  c = Cassandra.cluster(port: 9242)
-  c.connect(keyspace)
+  POOL[keyspace] ||= Cassandra.cluster(port: 9242).connect(keyspace)
 end
 
 def initialize_task_table


### PR DESCRIPTION
Tests sometimes fail because we are opening too many Cassandra
connections

```
Error:
a composite task#test_should_return_the_results_of_each_executed_child_task:
Errno::EMFILE: Too many open files
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/ione-1.2.3/lib/ione/io/io_reactor.rb:368:in `pipe'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/ione-1.2.3/lib/ione/io/io_reactor.rb:368:in `initialize'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/ione-1.2.3/lib/ione/io/io_reactor.rb:147:in `new'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/ione-1.2.3/lib/ione/io/io_reactor.rb:147:in `start'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/cassandra-driver-2.1.5/lib/cassandra/cluster/control_connection.rb:59:in `connect_async'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/cassandra-driver-2.1.5/lib/cassandra/driver.rb:146:in `connect'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/cassandra-driver-2.1.5/lib/cassandra.rb:519:in `cluster_async'
    /Users/Bodah/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/cassandra-driver-2.1.5/lib/cassandra.rb:211:in `cluster'
    /Users/Bodah/repos/backupify/task/test/test_helper.rb:17:in `session_for_keyspace'
    /Users/Bodah/repos/backupify/task/test/test_helper.rb:44:in `clear_task_table'
    /Users/Bodah/repos/backupify/task/test/task/tasks/composite_task_test.rb:29:in `block (2 levels) in <class:CompositeTaskTest>'
```

Cache and reuse them in a pool instead
